### PR TITLE
T6761 - Limitar o processo do Autovacum do Queue

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -412,7 +412,7 @@ class QueueJob(models.Model):
                 ['|',
                  ('date_done', '<=', deadline),
                  ('date_cancelled', '<=', deadline),
-                 ('channel', '=', channel.complete_name)],
+                 ('channel', '=', channel.complete_name)], limit=500,
             )
             if jobs:
                 jobs.unlink()


### PR DESCRIPTION
# Descrição

Limita autovacuum em 500 linhas modulo 'queue_job'

- Esse limitador ajuda em evitar um grande processo no banco de dados ao mesmo tempo, visto que é executado em CRON e não tem a necessidade de puxar a base inteira para ser executada.

# Informações adicionais

Dados da tarefa: [T6761](https://multi.multidados.tech/web?debug#id=7127&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)