### PR TITLE
T6810 - Ajustar Queue para retornar o Status para Pendente caso o Odoo seja reiniciado

### DIFF
--- a/queue_job/models/queue_job.py
+++ b/queue_job/models/queue_job.py
@@ -419,7 +419,7 @@ class QueueJob(models.Model):
         return True
 
     @api.model
-    def requeue_stuck_jobs(self, enqueued_delta=5, started_delta=0):
+    def requeue_stuck_jobs(self, enqueued_delta=5, started_delta=30):
         """Fix jobs that are in a bad states
         :param in_queue_delta: lookup time in minutes for jobs
                                 that are in enqueued state

--- a/test_base_import_async/__manifest__.py
+++ b/test_base_import_async/__manifest__.py
@@ -20,6 +20,6 @@
     'data': [
         'tests/data.xml',
     ],
-    'installable': True,
+    'installable': False,
     'development_status': 'Production/Stable',
 }

--- a/test_queue_job/__manifest__.py
+++ b/test_queue_job/__manifest__.py
@@ -14,5 +14,5 @@
      'data/queue_job_function_data.xml',
      'security/ir.model.access.csv',
  ],
- 'installable': True,
+ 'installable': False,
  }

--- a/test_queue_job_batch/__manifest__.py
+++ b/test_queue_job_batch/__manifest__.py
@@ -12,4 +12,5 @@
         'queue_job_batch',
         'test_queue_job',
     ],
+    'installable': False,
 }


### PR DESCRIPTION
# Descrição

Altera parametro reenfileirar processos modulo 'queue_job'

- Alterado parametro para também tratar os processos já iniciados e a partir de 30 min (default) serem reiniciados.

  Isso foi necessário pois ao reiniciar o Odoo, processos iniciados ficam ade eternos pois nunca são finalizados.

# Informações adicionais

Dados da tarefa: [T6810](https://multi.multidados.tech/web#id=7219&action=323&active_id=61&model=project.task&view_type=form&menu_id=223)


